### PR TITLE
Add Claude Code session start hook for web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Static HTML/CSS/JS site — no build dependencies required.
+# Ensure Python is available for local previewing.
+python3 --version > /dev/null 2>&1 && echo "Python available for http.server" || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a minimal `SessionStart` hook for Claude Code on the web. Since this is a pure static HTML/CSS/JS site with no build dependencies, the hook simply verifies Python is available for local previewing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQfc1BjVPcqTXySpUtH7qG)_